### PR TITLE
Fix container port issue

### DIFF
--- a/charts/shibboleth-idp/templates/deployment.yaml
+++ b/charts/shibboleth-idp/templates/deployment.yaml
@@ -35,7 +35,7 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: http
-              containerPort: {{ .Values.containerPort }}
+              containerPort: {{ .Values.service.containerPort }}
               protocol: TCP
           # Disabled until functionality can be tested
           # livenessProbe:

--- a/charts/shibboleth-idp/templates/service.yaml
+++ b/charts/shibboleth-idp/templates/service.yaml
@@ -8,7 +8,7 @@ spec:
   type: {{ .Values.service.type }}
   ports:
     - port: {{ .Values.service.port }}
-      targetPort:  {{ .Values.service.containerPort }}}}
+      targetPort:  {{ .Values.service.containerPort }}
       protocol: TCP
       name: http
   selector:


### PR DESCRIPTION
When I run 
```sh
helm install --generate-name .
```

I've got this error message
```
Error: INSTALLATION FAILED: Service "chart-1721123440-shibboleth-idp" is invalid: [spec.ports[0].targetPort: Invalid value: "8080}}": must contain only alpha-numeric characters (a-z, 0-9), and hyphens (-), spec.ports[0].targetPort: Invalid value: "8080}}": must contain at least one letter (a-z)]
```

This patch will fix that.